### PR TITLE
fix: avoid failing if less than 3 pipelines

### DIFF
--- a/store.go
+++ b/store.go
@@ -62,6 +62,14 @@ type Pipelines struct {
 	}
 }
 
+// RecentPipelines returns the recent pipelines for the header
+func (p *Pipelines) RecentPipelines() []Pipeline {
+	if len(p.Pipelines) <= 3 {
+		return p.Pipelines
+	}
+	return p.Pipelines[0:3]
+}
+
 func (s *Store) All() (*Pipelines, error) {
 	request := bleve.NewSearchRequest(bleve.NewMatchAllQuery())
 	request.SortBy([]string{"-Start"})

--- a/web/templates/home.tmpl
+++ b/web/templates/home.tmpl
@@ -17,7 +17,7 @@
         
 <section class="in-building">
     <div class="pipeline-cards">
-        {{ range slice .Pipelines.Pipelines 0 3 }}
+        {{ range slice .Pipelines.RecentPipelines }}
             <div class="pipeline-card">
                 <span class="repository"><a class="repository-link" href="/{{ .Owner }}/{{ .Repository }}">{{ .Owner }}/{{ .Repository }}</a></span>
                 <span class="pipeline">{{ .Context }}</span>


### PR DESCRIPTION
I found the home page was barfing with an index out of bounds error if there were less than 3 pipelines in a cluster

Signed-off-by: James Strachan <james.strachan@gmail.com>