### PR TITLE
perf: Improve logs performance 

### DIFF
--- a/web/static/app.css
+++ b/web/static/app.css
@@ -1,3 +1,9 @@
+#errors {
+    color: red;
+    background-color:black;
+    overflow-x: scroll;
+}
+
 .menu-bar {
     background-color: #040749;
     width: 50px;

--- a/web/templates/pipeline.tmpl
+++ b/web/templates/pipeline.tmpl
@@ -23,17 +23,27 @@
                 req.send();
             {{ else }}
                 const eventSource = new EventSource("/{{.Pipeline.Spec.GitOwner}}/{{.Pipeline.Spec.GitRepository}}/{{.Pipeline.Spec.GitBranch}}/{{.Pipeline.Spec.Build}}/logs/live");
+                let logsBuffer = "";
                 
                 eventSource.addEventListener("log", function(e) {
-                    logs.innerHTML += ansi_up.ansi_to_html(e.data + "\n");
-                    logs.scrollTop = logs.scrollHeight;
-                })
+                    logsBuffer += e.data + "\n";
+                }, {passive: true})
                 eventSource.addEventListener("error", function(e) {
                     errors.innerHTML = e.data;
                 })
                 eventSource.addEventListener("EOF", function(e) {
                     eventSource.close();
                 })
+
+                function repeatOften() {
+                    if(logsBuffer) {
+                        logs.insertAdjacentHTML('beforeend', ansi_up.ansi_to_html(logsBuffer));
+                        logsBuffer = "";
+                    }
+                    requestAnimationFrame(repeatOften);
+                }
+                // Waiting the next animation frame to add DOM element
+                requestAnimationFrame(repeatOften);         
             {{ end }}
         };
     </script>
@@ -94,6 +104,6 @@
     </ul>
 </section>
 <section class="pipelines">
-    <div id="errors"></div>
+    <pre id="errors"></pre>
     <pre id="logs"></pre>
 </section>


### PR DESCRIPTION
Some explanations :

## Before 🐢 

![Screenshot 2020-10-09 at 17 24 50](https://user-images.githubusercontent.com/7460283/95609735-81c0d000-0a5f-11eb-82b8-d26d4b4b95e4.png)

As you can see, the CPU (purple line on the top) was completely overloaded with CSS [layouts](https://developers.google.com/web/fundamentals/performance/rendering). This happens when we modify the DOM or when we change a CSS rule.
And we modified the DOM (with innerHTML) a huge number of time by second 🔥 .

## After 🏇 

![Screenshot 2020-10-09 at 18 10 06](https://user-images.githubusercontent.com/7460283/95609748-871e1a80-0a5f-11eb-9314-b0faea3f104a.png)

So now, we request an animation frame to change the DOM (it's better because it's the good time to change something on CSS or in the DOM) and we buffer logs during this time.
And we use [insertAdjacentHTML](https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML) which is better than innerHTML 😉 .

It's not perfect, but it's better I think 😄 
I will create in another PR some [Collapse component](https://ant.design/components/collapse/) to avoid to display all the logs in a row.

![](https://media.giphy.com/media/NhkMeVafqPkPK/giphy.gif)