### PR TITLE
fix: allow annotations to be added to the ServiceAccount

### DIFF
--- a/charts/jx-pipelines-visualizer/templates/rbac.yaml
+++ b/charts/jx-pipelines-visualizer/templates/rbac.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ include "jxpipelines.fullname" . }}
   labels: {{- include "jxpipelines.labels" . | nindent 4 }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/jx-pipelines-visualizer/values.yaml
+++ b/charts/jx-pipelines-visualizer/values.yaml
@@ -73,6 +73,11 @@ ingress:
     #  existing-secret-name: {}
     secrets: {}
 
+serviceAccount:
+  # allow additional annotations to be added to the ServiceAccount
+  # such as for workload identity on clouds
+  annotations: {}
+
 role:
   rules:
   - apiGroups:


### PR DESCRIPTION
for integration with cloud workload identity on GKE/EKS

Signed-off-by: James Strachan <james.strachan@gmail.com>