### PR TITLE
feat: Add color switch theme for logs

### DIFF
--- a/web/static/app.css
+++ b/web/static/app.css
@@ -1,10 +1,9 @@
 :root {
     --color-background: #ffffff;
     --color-background-darker: #f3f6fa;
+    --color-grey: #eaebec;
     --color-error: #ef476f;
-    --color-line-number: #1b1f234d;
-    --color-line-number-color-hover: #1b1f2399;
-    --color-line-selected: #6874f970;
+
     --color-pending: #073b4c;
     --color-running: #118ab2;
     --color-success: #06d6a0;
@@ -13,6 +12,10 @@
 
     --main-color: #6873f9;
     --main-color-darker: #040749;
+}
+
+* {
+	box-sizing: border-box;
 }
 
 body {

--- a/web/static/pipeline/index.js
+++ b/web/static/pipeline/index.js
@@ -4,10 +4,29 @@
     const errors = document.getElementById("errors");
 
     const followLogsCheckbox = document.querySelector('.follow-logs');
+    const logsTable = document.querySelector('.logs-table');
     const stickyHeader = document.querySelector('.header-hidden');
-    const stickyOption = document.querySelector('.follow-options');
+    const stickyOption = document.querySelector('.follow-option');
 
     const cssLineSelected = 'selected-line';
+
+    const addColorThemeOption = () => {
+        const themeSwitch = document.querySelector("#theme-switch");
+        themeSwitch.addEventListener('click', (e) => {
+            if(e.target.checked) {
+                logsTable.classList.add('logs-dark-theme');
+                localStorage.setItem('logs-dark-theme', true);
+            } else {
+                logsTable.classList.remove('logs-dark-theme');
+                localStorage.removeItem('logs-dark-theme');
+            }
+        });
+
+        // Init 
+        if (localStorage.getItem('logs-dark-theme')) {
+            themeSwitch.click();
+        }
+    };
 
     const transformLogIntoHtml = (lineNumber, text, type='') =>
         `<tr id="logsL${lineNumber}">
@@ -118,6 +137,7 @@
     // Run
 
     addScrollEvent();
+    addColorThemeOption();
 
     if (BUILD_LOG_URL) {
         loadByBuildLogUrl();

--- a/web/static/pipeline/main.css
+++ b/web/static/pipeline/main.css
@@ -2,7 +2,7 @@
     overflow: visible;
     font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
     font-size: 12px;
-    color: var(--color-text-primary);
+    color: var(--color-text-log);
     white-space: pre-wrap;
 }
 
@@ -31,7 +31,7 @@
 }
 
 .log-number:hover {
-    color: var(--line-number-color-hover);
+    color: var(--color-line-number-hover);
 }
 
 .log-line {
@@ -44,16 +44,35 @@
 }
 
 .logs-table {
-    background-color: #ffffff;
+    --color-text-log: #24292e;
+    --color-bg-log: #ffffff;
+
+    --color-line-number: #1b1f234d;
+    --color-line-number-hover: #1b1f2399;
+    --color-line-selected: #6874f970;
+
+    background-color: var(--color-bg-log);
     padding-top: 20px
+}
+
+.logs-dark-theme {
+    --color-bg-log: #1e1e1e;
+    --color-text-log: #f7f7f7;
+    --color-line-number: #d0d0d0;
+    --color-line-number-hover: #ffffff;
 }
 
 .logs-options {
     display: flex;
     flex-direction: row-reverse;
-    background-color: #ffffff;
+    background-color: var(--color-background);
     padding: 10px;
     border-bottom: 1px solid var(--color-background-darker);
+}
+
+.color-theme-option {
+    width: 90px;
+    margin-left: 40px;
 }
 
 .selected-line .log-number {
@@ -122,4 +141,88 @@
 
 .sticky-header h1 a{
     font-size: 15px;
+}
+
+/* Theme switch */
+
+.theme-switch__input,
+.theme-switch__label {
+	position: absolute;
+	z-index: 1;
+}
+
+.theme-switch__input {
+	opacity: 0;
+}
+
+.theme-switch__input:hover + .theme-switch__label,
+.theme-switch__input:focus + .theme-switch__label {
+    background-color: var(--color-grey);
+}
+
+.theme-switch__input:hover + .theme-switch__label span::after,
+.theme-switch__input:focus + .theme-switch__label span::after {
+	background-color: lighten(lightBlue, 10%);
+}
+
+.theme-switch__label {
+	transition: background-color 200ms ease-in-out;
+	width: 50px;
+	height: 20px;
+	border-radius: 50px;
+	text-align: center;
+	background-color: var(--color-background-darker);
+}
+
+.theme-switch__label::before,
+.theme-switch__label::after {
+    font-size: 1rem;
+    position: absolute;
+    transform: translate3d(0, -50%, 0);
+    top: 50%;
+}
+
+.theme-switch__label::before {
+    content: '\263C';
+    right: 100%;
+    margin-right: 10px;
+    color: orange;
+}
+
+.theme-switch__label::after {
+    content: '\263E';
+    left: 100%;
+    margin-left: 10px;
+    color: lightSlateGray;
+}
+
+.theme-switch__label span {
+    position: absolute;
+    bottom: calc(100% + 10px);
+    left: 0;
+    width: 100%;
+}
+
+.theme-switch__label span::after {
+    position: absolute;
+    top: calc(100% + 12px);
+    left: 5px;
+    width: 15px;
+    height: 15px;
+    content: '';
+    border-radius: 50%;
+    background-color: var(--main-color);
+    transition: transform 200ms, background-color 200ms;
+}
+
+.theme-switch__input:checked ~ .theme-switch__label::before {
+    color: lightSlateGray;
+}
+
+.theme-switch__input:checked ~ .theme-switch__label::after {
+    color: turquoise;
+}
+
+.theme-switch__input:checked ~ .theme-switch__label span::after {
+    transform: translate3d(25px, 0, 0);
 }

--- a/web/templates/pipeline.tmpl
+++ b/web/templates/pipeline.tmpl
@@ -81,7 +81,13 @@
 </section>
 <section class="pipelines">
     <div class="logs-options">
-        <div class="follow-options">
+        <div class="color-theme-option">
+            <input type="checkbox" id="theme-switch" name="theme-switch" class="theme-switch__input" />
+            <label for="theme-switch" class="theme-switch__label">
+                <span></span>
+            </label>
+        </div>
+        <div class="follow-option">
             <input class="follow-logs" type="checkbox" name="follow" checked>
             <label for="follow">Follow logs</label>
         </div>


### PR DESCRIPTION
## ☀️ 🌙 Add a color switch theme

Now, you can choose between light or dark color theme to display logs.
This information is saved inside your localstorage.

<img width="1440" alt="Screenshot 2020-10-19 at 08 36 12" src="https://user-images.githubusercontent.com/7460283/96409789-2670a980-11e6-11eb-8072-18cb8af5e92b.png">

![](https://media.giphy.com/media/koyjGfQHIZQKk/giphy.gif)

