### PR TITLE
fix: fix ingress & tls syntax #39

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,14 +74,12 @@ In the Git repository for your dev environment:
     tls:
       enabled: true
       secrets:
-      # re-use the existing tls secret managed by jx
-      {{- if .Requirements.ingress.tls.production }}
-      - name: tls-{{ .Requirements.ingress.domain | replace "." "-" }}-p
-      {{- else }}
-      - name: tls-{{ .Requirements.ingress.domain | replace "." "-" }}-s
-      {{- end }}
-        hosts: 
-        - pipelines{{.Requirements.ingress.namespaceSubDomain}}{{.Requirements.ingress.domain}}
+        # re-use the existing tls secret managed by jx
+        {{- if .Requirements.ingress.tls.production }}
+        tls-{{ .Requirements.ingress.domain | replace "." "-" }}-p: {}
+        {{- else }}
+        tls-{{ .Requirements.ingress.domain | replace "." "-" }}-s: {}
+        {{- end }}
     {{- end }}
     annotations:
       kubernetes.io/ingress.class: nginx

--- a/README.md
+++ b/README.md
@@ -74,12 +74,14 @@ In the Git repository for your dev environment:
     tls:
       enabled: true
       secrets:
-        # re-use the existing tls secret managed by jx
-        {{- if .Requirements.ingress.tls.production }}
-        tls-{{ .Requirements.ingress.domain | replace "." "-" }}-p: {}
-        {{- else }}
-        tls-{{ .Requirements.ingress.domain | replace "." "-" }}-s: {}
-        {{- end }}
+      # re-use the existing tls secret managed by jx
+      {{- if .Requirements.ingress.tls.production }}
+      - name: tls-{{ .Requirements.ingress.domain | replace "." "-" }}-p
+      {{- else }}
+      - name: tls-{{ .Requirements.ingress.domain | replace "." "-" }}-s
+      {{- end }}
+        hosts: 
+        - pipelines{{.Requirements.ingress.namespaceSubDomain}}{{.Requirements.ingress.domain}}
     {{- end }}
     annotations:
       kubernetes.io/ingress.class: nginx

--- a/charts/jx-pipelines-visualizer/templates/ingress.yaml
+++ b/charts/jx-pipelines-visualizer/templates/ingress.yaml
@@ -26,20 +26,20 @@ spec:
 
   {{- if .Values.ingress.tls.enabled }}
   tls:
-  {{- range $name, $secret := .Values.ingress.tls.secrets }}
-  {{- if and $secret.b64encodedCertificate $secret.b64encodedCertificateKey }}
-  - secretName: {{ include "jxpipelines.fullname" $ }}-tls-{{ $name }}
+  {{- range $secret := .Values.ingress.tls.secrets }}
+  {{- if and $secret.embedded }}
+  - secretName: {{ include "jxpipelines.fullname" $ }}-tls-{{ $secret.name }}
   {{- else }}
-  - secretName: {{ $name }}
+  - secretName: {{ $secret.name }}
+  {{- end }}
     hosts:
-{{- range $.Values.ingress.hosts }}
+{{- range $secret.hosts }}
     - {{ . }}
 {{- end }}
   {{- end }}
   {{- end }}
-  {{- end }}
 
-{{- if .Values.ingress.basicAuth.enabled -}}
+{{- if .Values.ingress.basicAuth.enabled }}
 ---
 apiVersion: v1
 data:
@@ -51,18 +51,18 @@ type: Opaque
 {{- end -}}
 
 {{- if .Values.ingress.tls.enabled -}}
-{{- range $name, $secret := .Values.ingress.tls.secrets -}}
-{{- if and $secret.b64encodedCertificate $secret.b64encodedCertificateKey }}
+{{- range $secret := .Values.ingress.tls.secrets -}}
+{{- if $secret.embedded }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "jxpipelines.fullname" $ }}-tls-{{ $name }}
+  name: {{ include "jxpipelines.fullname" $ }}-tls-{{ $secret.name }}
   labels: {{- include "jxpipelines.labels" $ | nindent 4 }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $secret.b64encodedCertificate | quote }}
-  tls.key: {{ $secret.b64encodedCertificateKey | quote }}
+  tls.crt: {{ $secret.embedded.b64encodedCertificate | quote }}
+  tls.key: {{ $secret.embedded.b64encodedCertificateKey | quote }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/jx-pipelines-visualizer/templates/ingress.yaml
+++ b/charts/jx-pipelines-visualizer/templates/ingress.yaml
@@ -26,14 +26,14 @@ spec:
 
   {{- if .Values.ingress.tls.enabled }}
   tls:
-  {{- range $secret := .Values.ingress.tls.secrets }}
-  {{- if and $secret.embedded }}
-  - secretName: {{ include "jxpipelines.fullname" $ }}-tls-{{ $secret.name }}
+  {{- range $name, $secret := .Values.ingress.tls.secrets }}
+  {{- if eq $name "embedded" }}
+  - secretName: {{ include "jxpipelines.fullname" $ }}-tls-{{ $name }}
   {{- else }}
-  - secretName: {{ $secret.name }}
+  - secretName: {{ $name }}
   {{- end }}
     hosts:
-{{- range $secret.hosts }}
+{{- range $.Values.ingress.hosts }}
     - {{ . }}
 {{- end }}
   {{- end }}
@@ -51,18 +51,18 @@ type: Opaque
 {{- end -}}
 
 {{- if .Values.ingress.tls.enabled -}}
-{{- range $secret := .Values.ingress.tls.secrets -}}
-{{- if $secret.embedded }}
+{{- range $name, $secret := .Values.ingress.tls.secrets -}}
+{{- if eq $name "embedded" }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "jxpipelines.fullname" $ }}-tls-{{ $secret.name }}
+  name: {{ include "jxpipelines.fullname" $ }}-tls-{{ $name }}
   labels: {{- include "jxpipelines.labels" $ | nindent 4 }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $secret.embedded.b64encodedCertificate | quote }}
-  tls.key: {{ $secret.embedded.b64encodedCertificateKey | quote }}
+  tls.crt: {{ $secret.b64encodedCertificate | quote }}
+  tls.key: {{ $secret.b64encodedCertificateKey | quote }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/jx-pipelines-visualizer/templates/ingress.yaml
+++ b/charts/jx-pipelines-visualizer/templates/ingress.yaml
@@ -27,15 +27,21 @@ spec:
   {{- if .Values.ingress.tls.enabled }}
   tls:
   {{- range $name, $secret := .Values.ingress.tls.secrets }}
-  {{- if eq $name "embedded" }}
+  {{- if and $secret.b64encodedCertificate $secret.b64encodedCertificateKey }}
   - secretName: {{ include "jxpipelines.fullname" $ }}-tls-{{ $name }}
   {{- else }}
   - secretName: {{ $name }}
   {{- end }}
     hosts:
-{{- range $.Values.ingress.hosts }}
+    {{- if $secret.hosts }}
+    {{- range $secret.hosts }}
     - {{ . }}
-{{- end }}
+    {{- end }}
+    {{- else }}
+    {{- range $.Values.ingress.hosts }}
+    - {{ . }}
+    {{- end }}
+    {{- end }}
   {{- end }}
   {{- end }}
 
@@ -52,7 +58,7 @@ type: Opaque
 
 {{- if .Values.ingress.tls.enabled -}}
 {{- range $name, $secret := .Values.ingress.tls.secrets -}}
-{{- if eq $name "embedded" }}
+{{- if and $secret.b64encodedCertificate $secret.b64encodedCertificateKey }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/jx-pipelines-visualizer/values.yaml
+++ b/charts/jx-pipelines-visualizer/values.yaml
@@ -66,11 +66,14 @@ ingress:
   tls:
     enabled: false
 
-    #secrets:
-    #  embedded:
-    #    b64encodedCertificate: e30k
-    #    b64encodedCertificateKey: e30k
-    #  existing-secret-name: {}
+    # if embedded is specified, a new secret will be created otherwise, it will use existing secret defined by name parameter
+    # secrets:
+    # - name: existing-secret-name
+    #   hosts: 
+    #   - pipelines.example.com
+    #   embedded:
+    #     b64encodedCertificate: e30k
+    #     b64encodedCertificateKey: e30k
     secrets: {}
 
 serviceAccount:

--- a/charts/jx-pipelines-visualizer/values.yaml
+++ b/charts/jx-pipelines-visualizer/values.yaml
@@ -55,6 +55,7 @@ ingress:
 
   # hosts:
   # - pipelines.example.com
+  # - pipelines.foo.bar
   hosts: []
 
 
@@ -70,7 +71,11 @@ ingress:
     #   embedded:
     #     b64encodedCertificate: e30k
     #     b64encodedCertificateKey: e30k
-    #   existing-secret-name: {}  
+    #     hosts:
+    #     - pipelines.example.com
+    #   existing-secret-name: {}
+    #     hosts:
+    #     - pipelines.foo.bar 
     secrets: {}
 
 serviceAccount:

--- a/charts/jx-pipelines-visualizer/values.yaml
+++ b/charts/jx-pipelines-visualizer/values.yaml
@@ -53,8 +53,8 @@ ingress:
   labels: {}
   annotations: {}
 
-  #hosts:
-  #- pipelines.example.com
+  # hosts:
+  # - pipelines.example.com
   hosts: []
 
 
@@ -66,14 +66,11 @@ ingress:
   tls:
     enabled: false
 
-    # if embedded is specified, a new secret will be created otherwise, it will use existing secret defined by name parameter
     # secrets:
-    # - name: existing-secret-name
-    #   hosts: 
-    #   - pipelines.example.com
     #   embedded:
     #     b64encodedCertificate: e30k
     #     b64encodedCertificateKey: e30k
+    #   existing-secret-name: {}  
     secrets: {}
 
 serviceAccount:

--- a/charts/jx-pipelines-visualizer/values.yaml
+++ b/charts/jx-pipelines-visualizer/values.yaml
@@ -74,6 +74,7 @@ ingress:
     #     hosts:
     #     - pipelines.example.com
     #   existing-secret-name: {}
+    #   existing-secret-name-with-custom-hosts:
     #     hosts:
     #     - pipelines.foo.bar 
     secrets: {}


### PR DESCRIPTION
fixes #39 

- Fix indentation issue between ingress & secret when tls is enabled
- Fix issue when using existing secret for tls when using helm chart

Warning, structure of secrets section in values.yaml is different to be able to have multiple secret if using multiple host for jx pipelines visualizer. So i also updated README.md but i can break changes for existing configuration when using new version.