### PR TITLE
feat: Read from log storage in AWS S3 using workload identity

### DIFF
--- a/charts/jx-pipelines-visualizer/templates/deployment.yaml
+++ b/charts/jx-pipelines-visualizer/templates/deployment.yaml
@@ -49,6 +49,13 @@ spec:
         - -log-level
         - {{ . }}
         {{- end }}
+        {{- if .Values.pod.env }}
+        env:
+        {{- range $pkey, $pval := .Values.pod.env }}
+        - name: {{ $pkey }}
+          value: {{ quote $pval }}
+        {{- end }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 8080
@@ -62,6 +69,9 @@ spec:
         {{- with .Values.pod.resources }}
         resources: {{- toYaml . | trim | nindent 10 }}
         {{- end }}
+      {{- with .Values.pod.securityContext }}
+      securityContext: {{- toYaml . | trim | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "jxpipelines.fullname" . }}
       enableServiceLinks: {{ .Values.pod.enableServiceLinks }}
       {{- with .Values.pod.activeDeadlineSeconds }}

--- a/charts/jx-pipelines-visualizer/values.yaml
+++ b/charts/jx-pipelines-visualizer/values.yaml
@@ -40,6 +40,9 @@ pod:
   tolerations: []
   hostAliases: []
   schedulerName:
+  securityContext:
+    fsGroup: 1000
+  env: {}
 
 service:
   port: 80


### PR DESCRIPTION
- When reading from AWS S3, `AWS_REGION` must be set as an environment variable. So let's add `env` to the chart.
- When using IAM Roles for Service Accounts for `jx-pipelines-visualizer`, the web token is mounted as a read only volume to `/var/run/secrets/eks.amazonaws.com/serviceaccount/`. Let's set `fsGroup` so that `jx` user can read those volumes.