### PR TITLE
fix: allow urls with or without final slash

### DIFF
--- a/web/handlers/router.go
+++ b/web/handlers/router.go
@@ -48,6 +48,7 @@ func (r Router) Handler() (http.Handler, error) {
 	})
 
 	router := mux.NewRouter()
+	router.StrictSlash(true)
 
 	kClient, err := kubernetes.NewForConfig(r.KConfig)
 	if err != nil {


### PR DESCRIPTION
previously, only the endpoints without final slash were valid.
if you put a final slash, it would return a 404.

this is now fixed, and both will answer.