### PR TITLE
fix: always set a start time for pipelines

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -47,6 +47,8 @@ func PipelineFromPipelineActivity(pa *jenkinsv1.PipelineActivity) Pipeline {
 	}
 	if pa.Spec.StartedTimestamp != nil {
 		p.Start = pa.Spec.StartedTimestamp.Time
+	} else {
+		p.Start = pa.CreationTimestamp.Time
 	}
 	if pa.Spec.CompletedTimestamp != nil {
 		p.End = pa.Spec.CompletedTimestamp.Time


### PR DESCRIPTION
even if a pipeline has no start time yet, fallback to the creation time of the pipelineactivity