### PR TITLE
feat: read pipelines from long-term storage

### DIFF
--- a/charts/jx-pipelines-visualizer/templates/deployment.yaml
+++ b/charts/jx-pipelines-visualizer/templates/deployment.yaml
@@ -45,6 +45,10 @@ spec:
         - -archived-logs-url-template
         - {{ . }}
         {{- end }}
+        {{- with .Values.config.archivedPipelinesURLTemplate }}
+        - -archived-pipelines-url-template
+        - {{ . }}
+        {{- end }}
         {{- with .Values.config.logLevel }}
         - -log-level
         - {{ . }}

--- a/charts/jx-pipelines-visualizer/values.yaml
+++ b/charts/jx-pipelines-visualizer/values.yaml
@@ -7,6 +7,8 @@ gitSecretName: tekton-git
 config:
   # gs://BUCKET_NAME/jenkins-x/logs/{{.Owner}}/{{.Repository}}/{{if hasPrefix .Branch \"pr\"}}{{.Branch | upper}}{{else}}{{.Branch}}{{end}}/{{.Build}}.log
   archivedLogsURLTemplate:
+  # gs://BUCKET_NAME/jenkins-x/logs/{{.Owner}}/{{.Repository}}/{{if hasPrefix .Branch \"pr\"}}{{.Branch | upper}}{{else}}{{.Branch}}{{end}}/{{.Build}}.yaml
+  archivedPipelinesURLTemplate:
   namespace: jx
   resyncInterval: 60s
   logLevel: INFO

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,13 +18,14 @@ import (
 
 var (
 	options struct {
-		namespace               string
-		resyncInterval          time.Duration
-		archivedLogsURLTemplate string
-		kubeConfigPath          string
-		listenAddr              string
-		logLevel                string
-		printVersion            bool
+		namespace                    string
+		resyncInterval               time.Duration
+		archivedLogsURLTemplate      string
+		archivedPipelinesURLTemplate string
+		kubeConfigPath               string
+		listenAddr                   string
+		logLevel                     string
+		printVersion                 bool
 	}
 
 	// these are set at compile time by GoReleaser through LD Flags
@@ -37,6 +38,7 @@ func init() {
 	flag.StringVar(&options.namespace, "namespace", "jx", "Name of the jx namespace")
 	flag.DurationVar(&options.resyncInterval, "resync-interval", 1*time.Minute, "Resync interval between full re-list operations")
 	flag.StringVar(&options.archivedLogsURLTemplate, "archived-logs-url-template", "", "Go template string used to build the archived logs URL")
+	flag.StringVar(&options.archivedPipelinesURLTemplate, "archived-pipelines-url-template", "", "Go template string used to build the archived pipelines URL")
 	flag.StringVar(&options.logLevel, "log-level", "INFO", "Log level - one of: trace, debug, info, warn(ing), error, fatal or panic")
 	flag.StringVar(&options.kubeConfigPath, "kubeconfig", kube.DefaultKubeConfigPath(), "Kubernetes Config Path. Default: KUBECONFIG env var value")
 	flag.StringVar(&options.listenAddr, "listen-addr", ":8080", "Address on which the server will listen for incoming connections")
@@ -87,12 +89,13 @@ func main() {
 	}).Start(ctx)
 
 	handler, err := handlers.Router{
-		Store:                   store,
-		KConfig:                 kClient.Config,
-		PAInterface:             jxClient.JenkinsV1().PipelineActivities(options.namespace),
-		Namespace:               options.namespace,
-		ArchivedLogsURLTemplate: options.archivedLogsURLTemplate,
-		Logger:                  logger,
+		Store:                        store,
+		KConfig:                      kClient.Config,
+		PAInterface:                  jxClient.JenkinsV1().PipelineActivities(options.namespace),
+		Namespace:                    options.namespace,
+		ArchivedLogsURLTemplate:      options.archivedLogsURLTemplate,
+		ArchivedPipelinesURLTemplate: options.archivedPipelinesURLTemplate,
+		Logger:                       logger,
 	}.Handler()
 	if err != nil {
 		logger.WithError(err).Fatal("failed to initialize the HTTP handler")

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/urfave/negroni/v2 v2.0.2
 	github.com/willf/bitset v1.1.11 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/apimachinery v0.19.3
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -880,6 +880,7 @@ github.com/jenkins-x/jx-pipeline v0.0.69 h1:oDYA9QWUvMpx22kggPOXDHB/udcSNesCmuaU
 github.com/jenkins-x/jx-pipeline v0.0.69/go.mod h1:55L2rcX+l8xgn5MVR8+yqKrKpk5qhhIEQClgSTlXji4=
 github.com/jenkins-x/jx-pipeline v0.0.71 h1:FBewzZnnKpLH6smXVZTaPxGD4oulxy+9QaD6Pp4YaBc=
 github.com/jenkins-x/jx-pipeline v0.0.71/go.mod h1:kh3uwSYtQ5i4d5BkEcoD/M9PbO0E0svWfdEae4PNnBk=
+github.com/jenkins-x/jx-pipeline v0.0.76 h1:t0pGmVDemGZ+EZEul0ZElGUiM4AOLnpI0AZqWSDp02M=
 github.com/jenkins-x/lighthouse v0.0.854/go.mod h1:0fZogTuRV3npYgg4gbR7XCXyJ06kLmhtKlzAC/vKtvc=
 github.com/jenkins-x/lighthouse v0.0.876/go.mod h1:6bxtTkLu6Yj5MOqZrMd6ueFDNlMxcpeDDMT6Xjh4/SE=
 github.com/jenkins-x/lighthouse v0.0.878/go.mod h1:VFtk1v2AlwCcmo3s67uUGP+vHqgwgv0Ld0lJlwsUnNc=

--- a/web/handlers/pipeline.go
+++ b/web/handlers/pipeline.go
@@ -5,20 +5,26 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"text/template"
+	"time"
 
 	"github.com/gorilla/mux"
 	jenkinsv1 "github.com/jenkins-x/jx-api/v4/pkg/apis/jenkins.io/v1"
 	jxclientv1 "github.com/jenkins-x/jx-api/v4/pkg/client/clientset/versioned/typed/jenkins.io/v1"
+	"github.com/jenkins-x/jx-pipeline/pkg/cloud/buckets"
 	"github.com/sirupsen/logrus"
 	"github.com/unrolled/render"
+	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type PipelineHandler struct {
-	PAInterface jxclientv1.PipelineActivityInterface
-	Render      *render.Render
-	Logger      *logrus.Logger
+	PAInterface                jxclientv1.PipelineActivityInterface
+	BuildLogsURLTemplate       *template.Template
+	StoredPipelinesURLTemplate *template.Template
+	Render                     *render.Render
+	Logger                     *logrus.Logger
 }
 
 func (h *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -39,8 +45,19 @@ func (h *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-
 	if errors.IsNotFound(err) {
+		pa = nil
+	}
+
+	if pa == nil {
+		pa, err = h.loadPipelineFromStorage(ctx, owner, repo, branch, build)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	if pa == nil {
 		err := h.Render.HTML(w, http.StatusOK, "archived_logs", map[string]string{
 			"Owner":      owner,
 			"Repository": repo,
@@ -63,4 +80,80 @@ func (h *PipelineHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+}
+
+func (h *PipelineHandler) loadPipelineFromStorage(ctx context.Context, owner, repo, branch, build string) (*jenkinsv1.PipelineActivity, error) {
+	storedPipelineURL, err := h.storedPipelineURL(owner, repo, branch, build)
+	if err != nil {
+		return nil, err
+	}
+
+	if storedPipelineURL == "" {
+		return nil, nil
+	}
+
+	httpFn := func(urlString string) (string, func(*http.Request), error) {
+		return urlString, func(*http.Request) {}, nil
+	}
+	reader, err := buckets.ReadURL(ctx, storedPipelineURL, 30*time.Second, httpFn)
+	if err != nil {
+		if strings.Contains(err.Error(), "object doesn't exist") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer reader.Close()
+
+	var pa jenkinsv1.PipelineActivity
+	err = yaml.NewDecoder(reader).Decode(&pa)
+	if err != nil {
+		return nil, err
+	}
+
+	if pa.Spec.BuildLogsURL == "" {
+		pa.Spec.BuildLogsURL, err = h.buildLogsURL(owner, repo, branch, build)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &pa, nil
+}
+
+func (h *PipelineHandler) storedPipelineURL(owner, repo, branch, build string) (string, error) {
+	if h.StoredPipelinesURLTemplate == nil {
+		return "", nil
+	}
+
+	sb := new(strings.Builder)
+	err := h.StoredPipelinesURLTemplate.Execute(sb, map[string]string{
+		"Owner":      owner,
+		"Repository": repo,
+		"Branch":     branch,
+		"Build":      build,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to generate stored pipeline URL: %w", err)
+	}
+
+	return sb.String(), nil
+}
+
+func (h *PipelineHandler) buildLogsURL(owner, repo, branch, build string) (string, error) {
+	if h.BuildLogsURLTemplate == nil {
+		return "", nil
+	}
+
+	sb := new(strings.Builder)
+	err := h.BuildLogsURLTemplate.Execute(sb, map[string]string{
+		"Owner":      owner,
+		"Repository": repo,
+		"Branch":     branch,
+		"Build":      build,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to generate build logs URL: %w", err)
+	}
+
+	return sb.String(), nil
 }

--- a/web/static/pipeline/index.js
+++ b/web/static/pipeline/index.js
@@ -114,16 +114,18 @@
     }
 
     const addDisplayStepsEvent = () => {
-        displayStepsCheckbox.addEventListener('click', function(event) {
-            var stages = document.querySelectorAll('.stage');
-            Array.from(stages).forEach(stage => {
-                if (displayStepsCheckbox.checked) {
-                    stage.classList.remove('steps-hidden');
-                } else {
-                    stage.classList.add('steps-hidden');
-                }
+        if (displayStepsCheckbox) {
+            displayStepsCheckbox.addEventListener('click', function(event) {
+                var stages = document.querySelectorAll('.stage');
+                Array.from(stages).forEach(stage => {
+                    if (displayStepsCheckbox.checked) {
+                        stage.classList.remove('steps-hidden');
+                    } else {
+                        stage.classList.add('steps-hidden');
+                    }
+                });
             });
-        });
+        }
     }
 
     const generateDownloadLink = (logs) => {

--- a/web/templates/pipeline.tmpl
+++ b/web/templates/pipeline.tmpl
@@ -142,7 +142,11 @@
                     {{end}}
                     <div class="clr-timeline-step-body">
                         <span class="clr-timeline-step-title" title="{{ $step.Description }}">
-                            <a href='#log-{{ $pipeStep.Stage.Name | lower | replace " " "-" }}-step-{{ $step.Name | lower | replace " " "-" }}'>{{ $step.Name }}</a>
+                            {{- if hasPrefix "step" (lower $step.Name) -}}
+                                <a href='#log-{{ $pipeStep.Stage.Name | lower | replace " " "-" }}-{{ $step.Name | lower | replace " " "-" }}'>{{ $step.Name }}</a>
+                            {{- else -}}
+                                <a href='#log-{{ $pipeStep.Stage.Name | lower | replace " " "-" }}-step-{{ $step.Name | lower | replace " " "-" }}'>{{ $step.Name }}</a>
+                            {{- end -}}
                         </span>
                         {{- if (eq $step.Status "Failed") -}}
                         <span class="clr-timeline-step-description">{{ $step.Description }}</span>


### PR DESCRIPTION
if the build controller stores pipelines in the long-term storage alongside the logs, we can retrieve them to display "old" pipelines