### PR TITLE
fix: don't cache static resources between releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ BUILDFLAGS :=  -ldflags \
 		-X $(ROOT_PACKAGE)/pkg/version.Branch='$(BRANCH)'\
 		-X $(ROOT_PACKAGE)/pkg/version.BuildDate='$(BUILD_DATE)'\
 		-X $(ROOT_PACKAGE)/pkg/version.GoVersion='$(GO_VERSION)'\
+		-X github.com/jenkins-x/jx-pipelines-visualizer/internal/version.Version=$(VERSION)\
+		-X github.com/jenkins-x/jx-pipelines-visualizer/internal/version.Revision='$(REV)'\
+		-X github.com/jenkins-x/jx-pipelines-visualizer/internal/version.Date='$(BUILD_DATE)'\
 		$(BUILD_TIME_CONFIG_FLAGS)"
 
 # Some tests expect default values for version.*, so just use the config package values there.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 
 	visualizer "github.com/jenkins-x/jx-pipelines-visualizer"
 	"github.com/jenkins-x/jx-pipelines-visualizer/internal/kube"
+	"github.com/jenkins-x/jx-pipelines-visualizer/internal/version"
 	"github.com/jenkins-x/jx-pipelines-visualizer/web/handlers"
 
 	jxclientset "github.com/jenkins-x/jx-api/v4/pkg/client/clientset/versioned"
@@ -27,11 +28,6 @@ var (
 		logLevel                     string
 		printVersion                 bool
 	}
-
-	// these are set at compile time by GoReleaser through LD Flags
-	version  = "dev"
-	revision = "unknown"
-	date     = "now"
 )
 
 func init() {
@@ -49,7 +45,7 @@ func main() {
 	flag.Parse()
 
 	if options.printVersion {
-		fmt.Printf("Version %s - Revision %s - Date %s", version, revision, date)
+		fmt.Printf("Version %s - Revision %s - Date %s", version.Version, version.Revision, version.Date)
 		return
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,8 @@
+package version
+
+// these are set at compile time by GoReleaser through LD Flags
+var (
+	Version  = "dev"
+	Revision = "unknown"
+	Date     = "now"
+)

--- a/store.go
+++ b/store.go
@@ -185,7 +185,7 @@ func bleveDocToPipeline(doc *search.DocumentMatch) Pipeline {
 }
 
 func addFacetRequests(request *bleve.SearchRequest) {
-	request.AddFacet("Status", bleve.NewFacetRequest("Status", 3))
+	request.AddFacet("Status", bleve.NewFacetRequest("Status", 4))
 	request.AddFacet("Repository", bleve.NewFacetRequest("Repository", 3))
 	request.AddFacet("Author", bleve.NewFacetRequest("Author", 3))
 	durationFacet := bleve.NewFacetRequest("Duration", 4)

--- a/web/handlers/functions/app.go
+++ b/web/handlers/functions/app.go
@@ -1,0 +1,9 @@
+package functions
+
+import (
+	"github.com/jenkins-x/jx-pipelines-visualizer/internal/version"
+)
+
+func AppVersion() string {
+	return version.Version
+}

--- a/web/handlers/router.go
+++ b/web/handlers/router.go
@@ -7,6 +7,7 @@ import (
 	"text/template"
 
 	visualizer "github.com/jenkins-x/jx-pipelines-visualizer"
+	"github.com/jenkins-x/jx-pipelines-visualizer/internal/version"
 	"github.com/jenkins-x/jx-pipelines-visualizer/web/handlers/functions"
 
 	"github.com/Masterminds/sprig/v3"
@@ -37,7 +38,7 @@ func (r Router) Handler() (http.Handler, error) {
 	r.render = render.New(render.Options{
 		Directory:     "web/templates",
 		Layout:        "layout",
-		IsDevelopment: true,
+		IsDevelopment: version.Version == "dev",
 		Funcs: []htmltemplate.FuncMap{
 			sprig.HtmlFuncMap(),
 			htmltemplate.FuncMap{
@@ -48,6 +49,7 @@ func (r Router) Handler() (http.Handler, error) {
 				"vdate":                  functions.VDate,
 				"sortPipelineCounts":     functions.SortPipelineCounts,
 				"isAvailable":            functions.IsAvailable,
+				"appVersion":             functions.AppVersion,
 			},
 		},
 	})

--- a/web/templates/archived_logs.tmpl
+++ b/web/templates/archived_logs.tmpl
@@ -1,5 +1,5 @@
 {{ define "css-archived_logs" }}
-    <link rel="stylesheet" href="/static/pipeline/main.css">
+    <link rel="stylesheet" href="/static/pipeline/main.css?v={{ appVersion }}">
 {{ end }}
 
 {{ define "js-archived_logs" }}
@@ -8,7 +8,7 @@
     LOGS_URL = "/{{.Owner}}/{{.Repository}}/{{.Branch}}/{{.Build}}";
 </script>
 <script src="/static/lib/ansi_up.js" type="text/javascript" defer></script>
-<script src="/static/pipeline/index.js" type="text/javascript" defer></script>
+<script src="/static/pipeline/index.js?v={{ appVersion }}" type="text/javascript" defer></script>
 {{ end }}
 
 {{ define "header-archived_logs" }}

--- a/web/templates/home.tmpl
+++ b/web/templates/home.tmpl
@@ -8,7 +8,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js" integrity="sha512-bLT0Qm9VnAYZDflyKcBaQ2gg0hSYNQrJ8RilYldYQ1FxQYoCLtUjuuRuZo+fjqhx/qtq/1itJ0C2ejDxltZVFg==" crossorigin="anonymous" type="text/javascript" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.21/js/jquery.dataTables.min.js" integrity="sha512-BkpSL20WETFylMrcirBahHfSnY++H2O1W+UnEEO4yNIl+jI2+zowyoGJpbtk6bx97fBXf++WJHSSK2MV4ghPcg==" crossorigin="anonymous" type="text/javascript" defer></script>
 <script src="/static/lib/clr-icons.min.js" type="text/javascript" defer></script>
-<script src="/static/home/index.js" type="text/javascript" defer></script>
+<script src="/static/home/index.js?v={{ appVersion }}" type="text/javascript" defer></script>
 {{ end }}
 
 {{ define "header-home" }}

--- a/web/templates/layout.tmpl
+++ b/web/templates/layout.tmpl
@@ -4,7 +4,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png">
     <link rel="stylesheet" href="/static/lib/clr-ui.min.css" />
-    <link href="/static/app.css" type="text/css" rel="stylesheet">
+    <link href="/static/app.css?v={{ appVersion }}" type="text/css" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {{ partial "js" }}
 </head>

--- a/web/templates/pipeline.tmpl
+++ b/web/templates/pipeline.tmpl
@@ -1,6 +1,6 @@
 {{ define "css-pipeline" }}
     <link rel="stylesheet" href="/static/lib/clr-icons.min.css">
-    <link rel="stylesheet" href="/static/pipeline/main.css">
+    <link rel="stylesheet" href="/static/pipeline/main.css?v={{ appVersion }}">
 {{ end }}
 
 {{ define "js-pipeline" }}
@@ -11,7 +11,7 @@
     <script src="/static/lib/custom-elements.min.js" defer></script>
     <script src="/static/lib/clr-icons.min.js" defer></script>
     <script src="/static/lib/ansi_up.js" type="text/javascript" defer></script>
-    <script src="/static/pipeline/index.js" type="text/javascript" defer></script>
+    <script src="/static/pipeline/index.js?v={{ appVersion }}" type="text/javascript" defer></script>
 {{ end }}
 
 {{ define "header-pipeline" }}


### PR DESCRIPTION
- add a query string with the version on our static resources, to avoid caching issue between releases
- don't recompile the go templates each time (unless we're in dev mode)