### PR TITLE
fix: pipelinerun handler should fail cleanly

### DIFF
--- a/web/handlers/pipelinerun.go
+++ b/web/handlers/pipelinerun.go
@@ -1,27 +1,25 @@
 package handlers
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 
-	jenkinsv1 "github.com/jenkins-x/jx-api/v4/pkg/apis/jenkins.io/v1"
+	"github.com/gorilla/mux"
 	jxclientv1 "github.com/jenkins-x/jx-api/v4/pkg/client/clientset/versioned/typed/jenkins.io/v1"
 	"github.com/jenkins-x/jx-pipeline/pkg/tektonlog"
 	visualizer "github.com/jenkins-x/jx-pipelines-visualizer"
-	tknclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
+	tknclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"github.com/unrolled/render"
-
-	"context"
-
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type PipelineRunHandler struct {
 	TektonClient tknclient.Interface
 	PAInterface  jxclientv1.PipelineActivityInterface
+	Namespace    string
 	Store        *visualizer.Store
 	Render       *render.Render
 	Logger       *logrus.Logger
@@ -32,15 +30,14 @@ func (h *PipelineRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	pipelineRunName := vars["pipelineRun"]
 	ns := vars["namespace"]
 	if ns == "" {
-		ns = "jx"
+		ns = h.Namespace
 	}
-	h.Logger.Info("rendering PipelineRun", pipelineRunName)
 
 	ctx := context.Background()
 	pr, err := h.TektonClient.TektonV1beta1().PipelineRuns(ns).Get(ctx, pipelineRunName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			h.RenderNotFound(w)
+			http.NotFound(w, r)
 		} else {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -48,16 +45,12 @@ func (h *PipelineRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pa, err := tektonlog.GetPipelineActivityForPipelineRun(context.TODO(), h.PAInterface, pr)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			h.RenderNotFound(w)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
+	if err != nil && !errors.IsNotFound(err) {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	if pa == nil {
-		h.RenderNotFound(w)
+		http.NotFound(w, r)
 		return
 	}
 
@@ -65,36 +58,6 @@ func (h *PipelineRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	repo := pa.Spec.GitRepository
 	branch := pa.Spec.GitBranch
 	build := pa.Spec.Build
-
-	if errors.IsNotFound(err) {
-		err := h.Render.HTML(w, http.StatusOK, "archived_logs", map[string]string{
-			"Owner":      owner,
-			"Repository": repo,
-			"Branch":     branch,
-			"Build":      build,
-		})
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		return
-	}
-
-	err = h.Render.HTML(w, http.StatusOK, "pipeline", struct {
-		Pipeline *jenkinsv1.PipelineActivity
-	}{
-		pa,
-	})
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-}
-
-func (h *PipelineRunHandler) RenderNotFound(w http.ResponseWriter) {
-	err := h.Render.HTML(w, http.StatusOK, "archived_logs", map[string]string{})
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	redirectURL := fmt.Sprintf("/%s/%s/%s/%s", owner, repo, branch, build)
+	http.Redirect(w, r, redirectURL, http.StatusMovedPermanently)
 }

--- a/web/handlers/router.go
+++ b/web/handlers/router.go
@@ -148,6 +148,7 @@ func (r Router) Handler() (http.Handler, error) {
 	router.Handle("/namespaces/{namespace}/pipelineruns/{pipelineRun}", &PipelineRunHandler{
 		TektonClient: tknClient,
 		PAInterface:  r.PAInterface,
+		Namespace:    r.Namespace,
 		Store:        r.Store,
 		Render:       r.render,
 		Logger:       r.Logger,


### PR DESCRIPTION
related to #54

if the pipelineruns handler doesn't find a pipelinerun or a matching pipelineactivity, then it should return a 404 instead of trying to render the archived logs template without any data.

the real fix for #54 should be to store the pipelineruns in the long-term storage, so we can retrieve them even if the pipelinerun has been garbage collected - see https://github.com/jenkins-x-plugins/jx-build-controller/issues/13