### PR TITLE
fix: CSS flexbox bug in safari

### DIFF
--- a/web/static/app.css
+++ b/web/static/app.css
@@ -75,6 +75,7 @@ body {
     padding: 10px 20px 30px;
     justify-content: space-between;
     background-color: var(--color-background-darker);
+    flex: 0 0 auto;
 }
 
 .pipeline-card {
@@ -171,7 +172,6 @@ pre#logs {
 .clr-timeline-step clr-icon[shape=dot-circle] {
     color: var(--color-running);
 }
-
 
 @media (max-width: 600px) {
     .pipeline-metadata {


### PR DESCRIPTION
Looks like Safari is miscalculating the height of an item in a flexbox. With this little tricks, we force the size of the element.

Tested on Chrome, Safari, Opera and Firefox.

![](https://media.giphy.com/media/BcJbdfFSsJPwK4O66J/giphy.gif)

Resolve #82