### PR TITLE
feat: support archived pipelineruns

### DIFF
--- a/charts/jx-pipelines-visualizer/templates/deployment.yaml
+++ b/charts/jx-pipelines-visualizer/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
         - -archived-pipelines-url-template
         - {{ . }}
         {{- end }}
+        {{- with .Values.config.archivedPipelineRunsURLTemplate }}
+        - -archived-pipelineruns-url-template
+        - {{ . }}
+        {{- end }}
         {{- with .Values.config.logLevel }}
         - -log-level
         - {{ . }}

--- a/charts/jx-pipelines-visualizer/values.yaml
+++ b/charts/jx-pipelines-visualizer/values.yaml
@@ -9,6 +9,8 @@ config:
   archivedLogsURLTemplate:
   # gs://BUCKET_NAME/jenkins-x/logs/{{.Owner}}/{{.Repository}}/{{if hasPrefix .Branch \"pr\"}}{{.Branch | upper}}{{else}}{{.Branch}}{{end}}/{{.Build}}.yaml
   archivedPipelinesURLTemplate:
+  # gs://BUCKET_NAME/jenkins-x/pipelineruns/{{.Namespace}}/{{.Name}}.yaml
+  archivedPipelineRunsURLTemplate:
   namespace: jx
   resyncInterval: 60s
   logLevel: INFO

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -19,14 +19,15 @@ import (
 
 var (
 	options struct {
-		namespace                    string
-		resyncInterval               time.Duration
-		archivedLogsURLTemplate      string
-		archivedPipelinesURLTemplate string
-		kubeConfigPath               string
-		listenAddr                   string
-		logLevel                     string
-		printVersion                 bool
+		namespace                       string
+		resyncInterval                  time.Duration
+		archivedLogsURLTemplate         string
+		archivedPipelinesURLTemplate    string
+		archivedPipelineRunsURLTemplate string
+		kubeConfigPath                  string
+		listenAddr                      string
+		logLevel                        string
+		printVersion                    bool
 	}
 )
 
@@ -35,6 +36,7 @@ func init() {
 	flag.DurationVar(&options.resyncInterval, "resync-interval", 1*time.Minute, "Resync interval between full re-list operations")
 	flag.StringVar(&options.archivedLogsURLTemplate, "archived-logs-url-template", "", "Go template string used to build the archived logs URL")
 	flag.StringVar(&options.archivedPipelinesURLTemplate, "archived-pipelines-url-template", "", "Go template string used to build the archived pipelines URL")
+	flag.StringVar(&options.archivedPipelineRunsURLTemplate, "archived-pipelineruns-url-template", "", "Go template string used to build the archived pipelineruns URL")
 	flag.StringVar(&options.logLevel, "log-level", "INFO", "Log level - one of: trace, debug, info, warn(ing), error, fatal or panic")
 	flag.StringVar(&options.kubeConfigPath, "kubeconfig", kube.DefaultKubeConfigPath(), "Kubernetes Config Path. Default: KUBECONFIG env var value")
 	flag.StringVar(&options.listenAddr, "listen-addr", ":8080", "Address on which the server will listen for incoming connections")
@@ -88,14 +90,15 @@ func main() {
 	}).Start(ctx)
 
 	handler, err := handlers.Router{
-		Store:                        store,
-		RunningPipelines:             runningPipelines,
-		KConfig:                      kClient.Config,
-		PAInterface:                  jxClient.JenkinsV1().PipelineActivities(options.namespace),
-		Namespace:                    options.namespace,
-		ArchivedLogsURLTemplate:      options.archivedLogsURLTemplate,
-		ArchivedPipelinesURLTemplate: options.archivedPipelinesURLTemplate,
-		Logger:                       logger,
+		Store:                           store,
+		RunningPipelines:                runningPipelines,
+		KConfig:                         kClient.Config,
+		PAInterface:                     jxClient.JenkinsV1().PipelineActivities(options.namespace),
+		Namespace:                       options.namespace,
+		ArchivedLogsURLTemplate:         options.archivedLogsURLTemplate,
+		ArchivedPipelinesURLTemplate:    options.archivedPipelinesURLTemplate,
+		ArchivedPipelineRunsURLTemplate: options.archivedPipelineRunsURLTemplate,
+		Logger:                          logger,
 	}.Handler()
 	if err != nil {
 		logger.WithError(err).Fatal("failed to initialize the HTTP handler")

--- a/web/handlers/pipelinerun.go
+++ b/web/handlers/pipelinerun.go
@@ -4,25 +4,33 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
+	"text/template"
+	"time"
 
 	"github.com/gorilla/mux"
 	jxclientv1 "github.com/jenkins-x/jx-api/v4/pkg/client/clientset/versioned/typed/jenkins.io/v1"
+	"github.com/jenkins-x/jx-pipeline/pkg/cloud/buckets"
+	"github.com/jenkins-x/jx-pipeline/pkg/pipelines"
 	"github.com/jenkins-x/jx-pipeline/pkg/tektonlog"
 	visualizer "github.com/jenkins-x/jx-pipelines-visualizer"
 	"github.com/sirupsen/logrus"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	tknclient "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"github.com/unrolled/render"
+	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type PipelineRunHandler struct {
-	TektonClient tknclient.Interface
-	PAInterface  jxclientv1.PipelineActivityInterface
-	Namespace    string
-	Store        *visualizer.Store
-	Render       *render.Render
-	Logger       *logrus.Logger
+	TektonClient                  tknclient.Interface
+	PAInterface                   jxclientv1.PipelineActivityInterface
+	StoredPipelineRunsURLTemplate *template.Template
+	Namespace                     string
+	Store                         *visualizer.Store
+	Render                        *render.Render
+	Logger                        *logrus.Logger
 }
 
 func (h *PipelineRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -35,29 +43,97 @@ func (h *PipelineRunHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	ctx := context.Background()
 	pr, err := h.TektonClient.TektonV1beta1().PipelineRuns(ns).Get(ctx, pipelineRunName, metav1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			http.NotFound(w, r)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		return
-	}
-
-	pa, err := tektonlog.GetPipelineActivityForPipelineRun(context.TODO(), h.PAInterface, pr)
 	if err != nil && !errors.IsNotFound(err) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if pa == nil {
+	if errors.IsNotFound(err) {
+		pr = nil
+	}
+
+	if pr == nil {
+		pr, err = h.loadPipelineRunFromStorage(ctx, ns, pipelineRunName)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	if pr == nil {
 		http.NotFound(w, r)
 		return
 	}
 
-	owner := pa.Spec.GitOwner
-	repo := pa.Spec.GitRepository
-	branch := pa.Spec.GitBranch
-	build := pa.Spec.Build
+	var (
+		owner  = pipelines.GetLabel(pr.Labels, pipelines.OwnerLabels)
+		repo   = pipelines.GetLabel(pr.Labels, pipelines.RepoLabels)
+		branch = pipelines.GetLabel(pr.Labels, pipelines.BranchLabels)
+		build  = pr.Labels["build"]
+	)
+	if owner == "" || repo == "" || branch == "" || build == "" {
+		pa, err := tektonlog.GetPipelineActivityForPipelineRun(context.TODO(), h.PAInterface, pr)
+		if err != nil && !errors.IsNotFound(err) {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if pa == nil {
+			http.NotFound(w, r)
+			return
+		}
+		owner = pa.Spec.GitOwner
+		repo = pa.Spec.GitRepository
+		branch = pa.Spec.GitBranch
+		build = pa.Spec.Build
+	}
+
 	redirectURL := fmt.Sprintf("/%s/%s/%s/%s", owner, repo, branch, build)
 	http.Redirect(w, r, redirectURL, http.StatusMovedPermanently)
+}
+
+func (h *PipelineRunHandler) loadPipelineRunFromStorage(ctx context.Context, namespace, name string) (*v1beta1.PipelineRun, error) {
+	storedPipelineRunURL, err := h.storedPipelineRunURL(namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if storedPipelineRunURL == "" {
+		return nil, nil
+	}
+
+	httpFn := func(urlString string) (string, func(*http.Request), error) {
+		return urlString, func(*http.Request) {}, nil
+	}
+	reader, err := buckets.ReadURL(ctx, storedPipelineRunURL, 30*time.Second, httpFn)
+	if err != nil {
+		if strings.Contains(err.Error(), "object doesn't exist") {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer reader.Close()
+
+	var pr v1beta1.PipelineRun
+	err = yaml.NewDecoder(reader).Decode(&pr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pr, nil
+}
+
+func (h *PipelineRunHandler) storedPipelineRunURL(namespace, name string) (string, error) {
+	if h.StoredPipelineRunsURLTemplate == nil {
+		return "", nil
+	}
+
+	sb := new(strings.Builder)
+	err := h.StoredPipelineRunsURLTemplate.Execute(sb, map[string]string{
+		"Namespace": namespace,
+		"Name":      name,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to generate stored pipeline run URL: %w", err)
+	}
+
+	return sb.String(), nil
 }


### PR DESCRIPTION
load pipelineruns from the long-term storage, so that we don't answer with 404 once the pipelineruns have been garbage-collected from the cluster
see https://github.com/jenkins-x-plugins/jx-build-controller/issues/13
and https://github.com/jenkins-x-plugins/jx-build-controller/pull/27