### PR TITLE
feat: status badge for shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is a Web UI for [Jenkins X](https://jenkins-x.io/), with a clear goal: **vi
 - Retrieve the archived pipelines logs from the long-term storage (GCS, S3, ...)
 - View all pipelines with their status, and filter/sort them
 - Read-only: only requires READ permissions on the Jenkins X and Tekton Pipelines CRDs
+- Expose a [Shields.io](https://shields.io/) compatible [endpoint](https://shields.io/endpoint)
 - Backward-compatible URLs with the old "JX UI" - so that you can easily swap the JXUI URL for the jx-pipelines-visualizer one in the Lighthouse config, and have Lighthouse set links to jx-pipelines-visualizer in GitHub Pull Requests.
 
 ### Screenshots
@@ -114,7 +115,15 @@ $ helm repo update
 $ helm install --name jx-pipelines-visualizer jx/jx-pipelines-visualizer
 ```
 
-## Configuration
+## Usage
+
+Just go to the homepage, and use the links to view the pipelines logs.
+
+To generate a status badge compatible with [shields.io](https://shields.io/):
+- read the [shields.io documentation](https://shields.io/endpoint)
+- the custom endpoint is: `https://YOUR_HOST/{owner}/{repo}/{branch}/shields.io` - for example `https://jx.example.com/my-org/my-repo/master/shields.io`. It returns a JSON response with the status of the latest build for the given branch.
+
+### Configuration
 
 See the [values.yaml](charts/jx-pipelines-visualizer/values.yaml) file for the configuration.
 

--- a/web/handlers/router.go
+++ b/web/handlers/router.go
@@ -146,6 +146,12 @@ func (r Router) Handler() (http.Handler, error) {
 		Logger: r.Logger,
 	})
 
+	router.Handle("/{owner}/{repo}/{branch}/shields.io", &ShieldsIOHandler{
+		Store:  r.Store,
+		Render: r.render,
+		Logger: r.Logger,
+	})
+
 	router.Handle("/{owner}/{repo}/{branch}/{build:[0-9]+}", &PipelineHandler{
 		PAInterface:                r.PAInterface,
 		StoredPipelinesURLTemplate: archivedPipelinesURLTemplate,

--- a/web/handlers/shields_io.go
+++ b/web/handlers/shields_io.go
@@ -1,0 +1,74 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	visualizer "github.com/jenkins-x/jx-pipelines-visualizer"
+	"github.com/sirupsen/logrus"
+	"github.com/unrolled/render"
+)
+
+// ShieldsIOBadge is documented at https://shields.io/endpoint
+type ShieldsIOBadge struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	Label         string `json:"label"`
+	Message       string `json:"message"`
+	Color         string `json:"color"`
+}
+
+type ShieldsIOHandler struct {
+	Store  *visualizer.Store
+	Render *render.Render
+	Logger *logrus.Logger
+}
+
+func (h *ShieldsIOHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	owner := vars["owner"]
+	repository := vars["repo"]
+	branch := vars["branch"]
+
+	pipelines, err := h.Store.Query(visualizer.Query{
+		Owner:      owner,
+		Repository: repository,
+		Branch:     branch,
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if len(pipelines.Pipelines) == 0 {
+		http.NotFound(w, r)
+		return
+	}
+	lastPipeline := pipelines.Pipelines[0]
+
+	shieldsIOBadge := ShieldsIOBadge{
+		SchemaVersion: 1,
+		Label:         "Jenkins X",
+		Message:       fmt.Sprintf("%s #%v %s", lastPipeline.Branch, lastPipeline.Build, lastPipeline.Status),
+		Color:         h.pipelineStatusToColor(lastPipeline.Status),
+	}
+
+	err = h.Render.JSON(w, http.StatusOK, shieldsIOBadge)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (h *ShieldsIOHandler) pipelineStatusToColor(status string) string {
+	switch status {
+	case "Succeeded":
+		return "green"
+	case "Failed":
+		return "red"
+	case "Running":
+		return "blue"
+	default:
+		return "grey"
+	}
+}


### PR DESCRIPTION
fixes #110

see https://shields.io/endpoint for the documentation
the new custom endpoint is `/{owner}/{repo}/{branch}/shields.io` - for example `/my-org/my-repo/master/shields.io`