### PR TITLE
feat: support pod.envFrom in values, for example to provide minio creds

### DIFF
--- a/charts/jx-pipelines-visualizer/templates/deployment.yaml
+++ b/charts/jx-pipelines-visualizer/templates/deployment.yaml
@@ -72,6 +72,10 @@ spec:
           value: {{ quote $pval }}
         {{- end }}
         {{- end }}
+        {{- with .Values.pod.envFrom }}
+        envFrom:
+          {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
         ports:
         - name: http
           containerPort: 8080

--- a/charts/jx-pipelines-visualizer/values.yaml
+++ b/charts/jx-pipelines-visualizer/values.yaml
@@ -50,7 +50,7 @@ pod:
   securityContext:
     fsGroup: 1000
   env: {}
-
+  envFrom: []
 service:
   port: 80
   type:


### PR DESCRIPTION
This feature is required to access logs stored in minio which doesn't use service accounts for auth but instead uses env vars