### PR TITLE
fix: Remove login:pass from origin if needed

### DIFF
--- a/web/static/pipeline/index.js
+++ b/web/static/pipeline/index.js
@@ -188,7 +188,9 @@
             .join('\n');
 
     const loadByBuildLogUrl = () => {
-        fetch(`${LOGS_URL}/logs`).then((response) => {
+        const hostnameWithoutLogin = window.location.origin.replace(/\/\/[^@]*@/, '//');
+   
+        fetch(`${hostnameWithoutLogin}${LOGS_URL}/logs`).then((response) => {
             if (response.status == 404) {
                 throw new Error('Archived logs not found in the long term storage');
             }


### PR DESCRIPTION
@jstrachan mentioned a problem with the origin of the URL such as: `https://login:password@host.com/`.
So, before making a fetch, we removed the `login:password` from the origin before.