### PR TITLE
fix: support links to gitlab and bitbucket

### DIFF
--- a/web/handlers/functions/pipeline.go
+++ b/web/handlers/functions/pipeline.go
@@ -1,22 +1,8 @@
 package functions
 
 import (
-	"fmt"
-	"strings"
-
 	jenkinsv1 "github.com/jenkins-x/jx-api/v4/pkg/apis/jenkins.io/v1"
 )
-
-func PipelinePullRequestURL(pa *jenkinsv1.PipelineActivity) string {
-	if !strings.HasPrefix(pa.Spec.GitBranch, "PR-") {
-		return "" // not a PR
-	}
-
-	prNumber := strings.TrimPrefix(pa.Spec.GitBranch, "PR-")
-	repoURL := strings.TrimSuffix(pa.Spec.GitURL, ".git")
-	prURL := fmt.Sprintf("%s/pull/%s", repoURL, prNumber)
-	return prURL
-}
 
 func PipelinePreviewEnvironmentApplicationURL(pa *jenkinsv1.PipelineActivity) string {
 	for _, stage := range pa.Spec.Steps {

--- a/web/handlers/router.go
+++ b/web/handlers/router.go
@@ -90,10 +90,10 @@ func (r Router) Handler() (http.Handler, error) {
 		Funcs: []htmltemplate.FuncMap{
 			sprig.HtmlFuncMap(),
 			htmltemplate.FuncMap{
-				"pipelinePullRequestURL":                   functions.PipelinePullRequestURL,
 				"pipelinePreviewEnvironmentApplicationURL": functions.PipelinePreviewEnvironmentApplicationURL,
 				"traceURL":           functions.TraceURLFunc(pipelineTraceURLTemplate),
 				"repositoryURL":      functions.RepositoryURL,
+				"prURL":              functions.PullRequestURL,
 				"branchURL":          functions.BranchURL,
 				"commitURL":          functions.CommitURL,
 				"authorURL":          functions.AuthorURL,

--- a/web/templates/pipeline.tmpl
+++ b/web/templates/pipeline.tmpl
@@ -143,11 +143,11 @@
                             {{- end -}}
                         </span>
                     </li>
-                    {{- if pipelinePullRequestURL .Pipeline -}}
+                    {{- if prURL .Pipeline -}}
                     <li>
                         <span class="title">PR</span>
                         <span>
-                            <a href="{{ pipelinePullRequestURL .Pipeline }}" title="{{ .Pipeline.Spec.PullTitle }}">{{ .Pipeline.Spec.GitBranch | replace "PR-" "" }}</a>
+                            <a href="{{ prURL .Pipeline }}" title="{{ .Pipeline.Spec.PullTitle }}">{{ .Pipeline.Spec.GitBranch | replace "PR-" "" }}</a>
                         </span>
                     </li>
                     {{- else -}}


### PR DESCRIPTION
fixes #124

we used to support "external" links (to repos, author, PRs, commits, ...) only to github, I've now added support for gitlab and bitbucket (cloud) too