### PR TITLE
fix: default Jenkins X config with host is failing with recent path changes

### DIFF
--- a/charts/jx-pipelines-visualizer/templates/ingress.yaml
+++ b/charts/jx-pipelines-visualizer/templates/ingress.yaml
@@ -32,6 +32,7 @@ spec:
   {{- end }}
 {{- else }}
   {{- $pathType := .Values.ingress.pathType | default "ImplementationSpecific" -}}
+  {{- $path  := .Values.ingress.path -}}
   {{- range .Values.ingress.hosts }}
   - host: {{ tpl . $ }}
     http:
@@ -42,8 +43,8 @@ spec:
             name: {{ include "jxpipelines.fullname" $ }}
             port:
               name: http
-        {{- if eq .Values.ingress.pathType "Prefix" }}
-        path: {{ .Values.ingress.path | default "/" }}
+        {{- if eq $pathType "Prefix" }}
+        path: {{ $path | default "/" }}
         {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
we need to scope values so we can access them in them here, this link helped with the fix https://stackoverflow.com/a/56671939/5010477

fixes the downsteam CI failure https://github.com/jenkins-x/jx3-versions/pull/2825
