### PR TITLE
feat: Support for multiple namespaces with preserving backwards comability

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a Web UI for [Jenkins X](https://jenkins-x.io/), with a clear goal: **vi
 - Read-only: only requires READ permissions on the Jenkins X and Tekton Pipelines CRDs
 - Expose a [Shields.io](https://shields.io/) compatible [endpoint](https://shields.io/endpoint)
 - Backward-compatible URLs with the old "JX UI" - so that you can easily swap the JXUI URL for the jx-pipelines-visualizer one in the Lighthouse config, and have Lighthouse set links to jx-pipelines-visualizer in GitHub Pull Requests.
+- Work in context of a single namespace or in a cluster context
 
 ### Screenshots
 

--- a/charts/jx-pipelines-visualizer/values.yaml
+++ b/charts/jx-pipelines-visualizer/values.yaml
@@ -13,6 +13,8 @@ config:
   archivedPipelineRunsURLTemplate:
   # https://GRAFANA_URL/explore?left=%5B%22now%22,%22now%22,%22Tempo%22,%7B%22query%22:%22{{.TraceID}}%22%7D%5D
   pipelineTraceURLTemplate:
+
+  # Set a fixed namespace if the visualizer should show pipelines only from selected namespace
   #namespace: jx
   resyncInterval: 60s
   logLevel: INFO

--- a/charts/jx-pipelines-visualizer/values.yaml
+++ b/charts/jx-pipelines-visualizer/values.yaml
@@ -13,7 +13,7 @@ config:
   archivedPipelineRunsURLTemplate:
   # https://GRAFANA_URL/explore?left=%5B%22now%22,%22now%22,%22Tempo%22,%7B%22query%22:%22{{.TraceID}}%22%7D%5D
   pipelineTraceURLTemplate:
-  namespace: jx
+  #namespace: jx
   resyncInterval: 60s
   logLevel: INFO
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -9,6 +9,7 @@ import (
 
 type Pipeline struct {
 	Name            string
+	Namespace       string
 	Provider        string
 	Owner           string
 	Repository      string
@@ -23,6 +24,7 @@ type Pipeline struct {
 	Start           time.Time
 	End             time.Time
 	Duration        time.Duration
+	GitUrl          string
 }
 
 func (p Pipeline) PullRequestNumber() string {
@@ -46,6 +48,8 @@ func PipelineFromPipelineActivity(pa *jenkinsv1.PipelineActivity) Pipeline {
 		Commit:          pa.Spec.LastCommitSHA,
 		Status:          string(pa.Spec.Status),
 		Description:     pa.Annotations["description"],
+		Namespace:       pa.Namespace,
+		GitUrl:          strings.TrimSuffix(pa.Spec.GitURL, ".git"),
 	}
 	if pa.Spec.StartedTimestamp != nil {
 		p.Start = pa.Spec.StartedTimestamp.Time

--- a/store.go
+++ b/store.go
@@ -167,6 +167,7 @@ func bleveDocToPipeline(doc *search.DocumentMatch) Pipeline {
 	}
 	return Pipeline{
 		Name:            doc.Fields["Name"].(string),
+		Namespace:       doc.Fields["Namespace"].(string),
 		Provider:        doc.Fields["Provider"].(string),
 		Owner:           doc.Fields["Owner"].(string),
 		Repository:      doc.Fields["Repository"].(string),
@@ -178,6 +179,7 @@ func bleveDocToPipeline(doc *search.DocumentMatch) Pipeline {
 		Commit:          doc.Fields["Commit"].(string),
 		Status:          doc.Fields["Status"].(string),
 		Description:     doc.Fields["Description"].(string),
+		GitUrl:          doc.Fields["GitUrl"].(string),
 		Start:           startDate,
 		End:             endDate,
 		Duration:        time.Duration(doc.Fields["Duration"].(float64)),

--- a/web/handlers/functions/links.go
+++ b/web/handlers/functions/links.go
@@ -104,6 +104,10 @@ func authorURLForPipelineActivity(pa *jenkinsv1.PipelineActivity) string {
 }
 
 func repositoryURLForPipeline(pipeline visualizer.Pipeline) string {
+	if pipeline.GitUrl != "" {
+		return pipeline.GitUrl
+	}
+
 	switch pipeline.Provider {
 	case "github":
 		return fmt.Sprintf("https://github.com/%s/%s", pipeline.Owner, pipeline.Repository)
@@ -137,8 +141,16 @@ func pullRequestURLForPipeline(pipeline visualizer.Pipeline) string {
 	case "github":
 		return fmt.Sprintf("https://github.com/%s/%s/pull/%s", pipeline.Owner, pipeline.Repository, pipeline.PullRequestNumber())
 	case "gitlab":
+		if pipeline.GitUrl != "" {
+			return fmt.Sprintf("%s/%s/%s/-/merge_requests/%s", pipeline.GitUrl, pipeline.Owner, pipeline.Repository, pipeline.PullRequestNumber())
+		}
+
 		return fmt.Sprintf("https://gitlab.com/%s/%s/-/merge_requests/%s", pipeline.Owner, pipeline.Repository, pipeline.PullRequestNumber())
 	case "bitbucket":
+		if pipeline.GitUrl != "" {
+			return fmt.Sprintf("%s/%s/%s/pull-requests/%s", pipeline.GitUrl, pipeline.Owner, pipeline.Repository, pipeline.PullRequestNumber())
+		}
+
 		return fmt.Sprintf("https://bitbucket.org/%s/%s/pull-requests/%s", pipeline.Owner, pipeline.Repository, pipeline.PullRequestNumber())
 	default:
 		return ""

--- a/web/handlers/router.go
+++ b/web/handlers/router.go
@@ -27,8 +27,9 @@ type Router struct {
 	Store                           *visualizer.Store
 	RunningPipelines                *visualizer.RunningPipelines
 	KConfig                         *rest.Config
-	PAInterface                     jenkinsv1.PipelineActivityInterface
+	PAInterfaceFactory              func(namespace string) jenkinsv1.PipelineActivityInterface
 	Namespace                       string
+	DefaultJXNamespace              string
 	ArchivedLogsURLTemplate         string
 	ArchivedPipelinesURLTemplate    string
 	ArchivedPipelineRunsURLTemplate string
@@ -152,16 +153,27 @@ func (r Router) Handler() (http.Handler, error) {
 		Logger: r.Logger,
 	})
 
-	router.Handle("/{owner}/{repo}/{branch}/{build:[0-9]+}", &PipelineHandler{
-		PAInterface:                r.PAInterface,
+	router.Handle("/ns-{namespace}/{owner}/{repo}/{branch}/{build:[0-9]+}", &PipelineHandler{
+		PAInterfaceFactory:         r.PAInterfaceFactory,
+		DefaultJXNamespace:         r.DefaultJXNamespace,
 		StoredPipelinesURLTemplate: archivedPipelinesURLTemplate,
 		BuildLogsURLTemplate:       archivedLogsURLTemplate,
 		Render:                     r.render,
 		Logger:                     r.Logger,
 	})
 
-	router.Handle("/{owner}/{repo}/{branch}/{build:[0-9]+}.yaml", &PipelineHandler{
-		PAInterface:                r.PAInterface,
+	router.Handle("/{owner}/{repo}/{branch}/{build:[0-9]+}", &PipelineHandler{
+		PAInterfaceFactory:         r.PAInterfaceFactory,
+		DefaultJXNamespace:         r.DefaultJXNamespace,
+		StoredPipelinesURLTemplate: archivedPipelinesURLTemplate,
+		BuildLogsURLTemplate:       archivedLogsURLTemplate,
+		Render:                     r.render,
+		Logger:                     r.Logger,
+	})
+
+	router.Handle("/ns-{namespace}/{owner}/{repo}/{branch}/{build:[0-9]+}.yaml", &PipelineHandler{
+		PAInterfaceFactory:         r.PAInterfaceFactory,
+		DefaultJXNamespace:         r.DefaultJXNamespace,
 		StoredPipelinesURLTemplate: archivedPipelinesURLTemplate,
 		BuildLogsURLTemplate:       archivedLogsURLTemplate,
 		RenderYAML:                 true,
@@ -169,26 +181,52 @@ func (r Router) Handler() (http.Handler, error) {
 		Logger:                     r.Logger,
 	})
 
-	router.Handle("/{owner}/{repo}/{branch}/{build:[0-9]+}/logs", &LogsHandler{
-		PAInterface:          r.PAInterface,
+	router.Handle("/{owner}/{repo}/{branch}/{build:[0-9]+}.yaml", &PipelineHandler{
+		PAInterfaceFactory:         r.PAInterfaceFactory,
+		DefaultJXNamespace:         r.DefaultJXNamespace,
+		StoredPipelinesURLTemplate: archivedPipelinesURLTemplate,
+		BuildLogsURLTemplate:       archivedLogsURLTemplate,
+		RenderYAML:                 true,
+		Render:                     r.render,
+		Logger:                     r.Logger,
+	})
+
+	router.Handle("/ns-{namespace}/{owner}/{repo}/{branch}/{build:[0-9]+}/logs", &LogsHandler{
+		PAInterfaceFactory:   r.PAInterfaceFactory, // todo
+		DefaultJXNamespace:   r.DefaultJXNamespace,
 		BuildLogsURLTemplate: archivedLogsURLTemplate,
 		Logger:               r.Logger,
 	})
 
+	router.Handle("/{owner}/{repo}/{branch}/{build:[0-9]+}/logs", &LogsHandler{
+		PAInterfaceFactory:   r.PAInterfaceFactory, // todo
+		DefaultJXNamespace:   r.DefaultJXNamespace,
+		BuildLogsURLTemplate: archivedLogsURLTemplate,
+		Logger:               r.Logger,
+	})
+
+	router.Handle("/ns-{namespace}/{owner}/{repo}/{branch}/{build:[0-9]+}/logs/live", &LiveLogsHandler{
+		DefaultJXNamespace: r.DefaultJXNamespace,
+		KubeClient:         kClient,
+		JXClient:           jxClient,
+		TektonClient:       tknClient,
+		Broker:             sse.NewBroker(nil),
+		Logger:             r.Logger,
+	})
+
 	router.Handle("/{owner}/{repo}/{branch}/{build:[0-9]+}/logs/live", &LiveLogsHandler{
-		KubeClient:   kClient,
-		JXClient:     jxClient,
-		TektonClient: tknClient,
-		Namespace:    r.Namespace,
-		Broker:       sse.NewBroker(nil),
-		Logger:       r.Logger,
+		DefaultJXNamespace: r.DefaultJXNamespace,
+		KubeClient:         kClient,
+		JXClient:           jxClient,
+		TektonClient:       tknClient,
+		Broker:             sse.NewBroker(nil),
+		Logger:             r.Logger,
 	})
 
 	router.Handle("/namespaces/{namespace}/pipelineruns/{pipelineRun}", &PipelineRunHandler{
 		TektonClient:                  tknClient,
-		PAInterface:                   r.PAInterface,
 		StoredPipelineRunsURLTemplate: archivedPipelineRunsURLTemplate,
-		Namespace:                     r.Namespace,
+		Namespace:                     r.Namespace, // todo?
 		Store:                         r.Store,
 		Render:                        r.render,
 		Logger:                        r.Logger,

--- a/web/handlers/router.go
+++ b/web/handlers/router.go
@@ -192,14 +192,14 @@ func (r Router) Handler() (http.Handler, error) {
 	})
 
 	router.Handle("/ns-{namespace}/{owner}/{repo}/{branch}/{build:[0-9]+}/logs", &LogsHandler{
-		PAInterfaceFactory:   r.PAInterfaceFactory, // todo
+		PAInterfaceFactory:   r.PAInterfaceFactory,
 		DefaultJXNamespace:   r.DefaultJXNamespace,
 		BuildLogsURLTemplate: archivedLogsURLTemplate,
 		Logger:               r.Logger,
 	})
 
 	router.Handle("/{owner}/{repo}/{branch}/{build:[0-9]+}/logs", &LogsHandler{
-		PAInterfaceFactory:   r.PAInterfaceFactory, // todo
+		PAInterfaceFactory:   r.PAInterfaceFactory,
 		DefaultJXNamespace:   r.DefaultJXNamespace,
 		BuildLogsURLTemplate: archivedLogsURLTemplate,
 		Logger:               r.Logger,
@@ -226,7 +226,7 @@ func (r Router) Handler() (http.Handler, error) {
 	router.Handle("/namespaces/{namespace}/pipelineruns/{pipelineRun}", &PipelineRunHandler{
 		TektonClient:                  tknClient,
 		StoredPipelineRunsURLTemplate: archivedPipelineRunsURLTemplate,
-		Namespace:                     r.Namespace, // todo?
+		Namespace:                     r.Namespace,
 		Store:                         r.Store,
 		Render:                        r.render,
 		Logger:                        r.Logger,

--- a/web/handlers/router.go
+++ b/web/handlers/router.go
@@ -224,6 +224,7 @@ func (r Router) Handler() (http.Handler, error) {
 	})
 
 	router.Handle("/namespaces/{namespace}/pipelineruns/{pipelineRun}", &PipelineRunHandler{
+		PAInterfaceFactory:            r.PAInterfaceFactory,
 		TektonClient:                  tknClient,
 		StoredPipelineRunsURLTemplate: archivedPipelineRunsURLTemplate,
 		Namespace:                     r.Namespace,

--- a/web/static/pipeline/main.css
+++ b/web/static/pipeline/main.css
@@ -147,7 +147,7 @@
 
 .pipeline-card ul li span.title {
     display: inline-block;
-    width: 60px;
+    width: 100px;
 }
 
 .pipeline-card ul.stages {

--- a/web/templates/archived_logs.tmpl
+++ b/web/templates/archived_logs.tmpl
@@ -51,7 +51,7 @@
         <div class="follow-option"></div>
         <div class="raw-logs-options">
             <button class="option-button" id="toggle-steps">Toggle Steps</button>
-            <a class="option-button" href="/{{.Owner}}/{{.Repository}}/{{.Branch}}/{{.Build}}/logs" target="_blank">View raw logs</a>
+            <a class="option-button" href="/ns-{{.Namespace}}/{{.Owner}}/{{.Repository}}/{{.Branch}}/{{.Build}}/logs" target="_blank">View raw logs</a>
             <a class="option-button" id="downloadLogs" disabled="true" download="{{.Owner}}-{{.Repository}}-{{.Branch}}-{{.Build}}.txt">Download raw logs</a>
         </div>
     </div>

--- a/web/templates/home.tmpl
+++ b/web/templates/home.tmpl
@@ -163,7 +163,7 @@
                     </span>
                     {{- end -}}
                 </td>
-                <td><a href="/{{ .Owner }}/{{ .Repository }}/{{ .Branch }}/{{ .Build }}">{{ .Build }}</a></td>
+                <td><a href="/ns-{{ .Namespace }}/{{ .Owner }}/{{ .Repository }}/{{ .Branch }}/{{ .Build }}">{{ .Build }}</a></td>
                 <td>{{ .Context }}</td>
                 <td class="status-{{ lower .Status }}" title="{{ .Description }}">{{ .Status }}</td>
                 <td data-order='{{ .Start.Format "2006-01-02 15:04:05" }}'>

--- a/web/templates/pipeline.tmpl
+++ b/web/templates/pipeline.tmpl
@@ -6,7 +6,7 @@
 {{ define "js-pipeline" }}
     <script type="text/javascript">
         BUILD_LOG_URL = "{{.Pipeline.Spec.BuildLogsURL}}";
-        LOGS_URL = "/{{.Pipeline.Spec.GitOwner}}/{{.Pipeline.Spec.GitRepository}}/{{.Pipeline.Spec.GitBranch}}/{{.Pipeline.Spec.Build}}";
+        LOGS_URL = "/ns-{{.Pipeline.Namespace}}/{{.Pipeline.Spec.GitOwner}}/{{.Pipeline.Spec.GitRepository}}/{{.Pipeline.Spec.GitBranch}}/{{.Pipeline.Spec.Build}}";
         ARCHIVE = false;
         STEPS = {
             {{- range $pipeStep := .Pipeline.Spec.Steps -}}
@@ -76,6 +76,10 @@
                         <span>{{ .Pipeline.Name }}</span>
                     </li>
                     <li>
+                        <span class="title">Namespace</span>
+                        <span>{{ .Pipeline.Namespace }}</span>
+                    </li>
+                    <li>
                         <span class="title">Context</span>
                         <span>{{ .Pipeline.Spec.Context }}</span>
                     </li>
@@ -86,7 +90,7 @@
                     <li>
                         <span class="title">YAML</span>
                         <span>
-                            <a href="/{{.Pipeline.Spec.GitOwner}}/{{.Pipeline.Spec.GitRepository}}/{{.Pipeline.Spec.GitBranch}}/{{.Pipeline.Spec.Build}}.yaml" target="_blank">View raw YAML</a>
+                            <a href="/ns-{{.Pipeline.Namespace}}/{{.Pipeline.Spec.GitOwner}}/{{.Pipeline.Spec.GitRepository}}/{{.Pipeline.Spec.GitBranch}}/{{.Pipeline.Spec.Build}}.yaml" target="_blank">View raw YAML</a>
                         </span>
                     </li>
                 </ul>
@@ -342,7 +346,7 @@
         </div>
         <div class="raw-logs-options">
             <button class="option-button" id="toggle-steps">Toggle Steps</button>
-            <a class="option-button" href="/{{.Pipeline.Spec.GitOwner}}/{{.Pipeline.Spec.GitRepository}}/{{.Pipeline.Spec.GitBranch}}/{{.Pipeline.Spec.Build}}/logs" target="_blank">View raw logs</a>
+            <a class="option-button" href="/ns-{{.Pipeline.Namespace}}/{{.Pipeline.Spec.GitOwner}}/{{.Pipeline.Spec.GitRepository}}/{{.Pipeline.Spec.GitBranch}}/{{.Pipeline.Spec.Build}}/logs" target="_blank">View raw logs</a>
             <a class="option-button" id="downloadLogs" download="{{.Pipeline.Spec.GitOwner}}-{{.Pipeline.Spec.GitRepository}}-{{.Pipeline.Spec.GitBranch}}-{{.Pipeline.Spec.Build}}.txt">Download raw logs</a>
         </div>
     </div>


### PR DESCRIPTION
**Features:**
- Adds additional prefixed endpoints that includes namespace name
- Backwards compatiblility with non-prefixed links (could be deprecated and removed in future)
- Prints namespace in job execution details
- By default listens on all namespaces
- **Visualizer can now show pipelines in scope of single namespace, or cluster-wide**. Can be installed per-team-namespace or as a central viewer. Defaults to central viewer as Jenkins X does not support installation per-namespace

Part of https://github.com/jenkins-x/lighthouse/pull/1424
--------------------------------------------------------------------------

![image](https://user-images.githubusercontent.com/372403/157447763-d2fbb9a7-0827-4c7f-a0e2-704767aa5a4f.png)
