### PR TITLE
Fix chart syntax

### DIFF
--- a/charts/jx-pipelines-visualizer/templates/istio.yaml
+++ b/charts/jx-pipelines-visualizer/templates/istio.yaml
@@ -5,7 +5,11 @@ metadata:
   name: {{ include "jxpipelines.fullname" $ }}
 spec:
   gateways:
-  - {{ .Values.istio.gateway }}
+{{- if .Values.istio.createGateway }}
+  - jx-gateway
+{{- else }}
+  - {{ .Values.istio.gateway.name }}
+{{- end }}
   hosts:
   - dashboard{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
   http:


### PR DESCRIPTION
This makes pipeline use the same istio syntax as other charts such as chartmuseum