### PR TITLE
feat: add Gateway API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ In the Git repository for your dev environment:
     annotations:
       kubernetes.io/ingress.class: nginx
   ```
-  
+
   This will expose the UI at `pipelines.your.domain.tld` - without any auth. You can add [basic auth by appending a few additional annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#authentication) - re-using the Jenkins X Auth Secret:
 
   ```
   nginx.ingress.kubernetes.io/auth-type: basic
   nginx.ingress.kubernetes.io/auth-secret: jx-basic-auth
   ```
-  
+
 - If you want [Lighthouse](https://github.com/jenkins-x/lighthouse) to add links to your jx-pipelines-visualizer instance from your Pull/Merge Request checks, update the `env/lighthouse-jx/values.tmpl.yaml` file and add the following:
   ```
   env:
@@ -115,6 +115,69 @@ $ helm repo add jx https://jenkins-x-charts.github.io/repo
 $ helm repo update
 $ helm install --name jx-pipelines-visualizer jx/jx-pipelines-visualizer
 ```
+
+### With the Gateway API (instead of an Ingress)
+
+As an alternative to the Ingress resource, the chart can expose the UI through the
+Kubernetes [Gateway API](https://gateway-api.sigs.k8s.io/) by creating an `HTTPRoute`.
+Enable it via the `gatewayApi` values block:
+
+```yaml
+gatewayApi:
+  enabled: true
+  # the (pre-existing) Gateway to attach to
+  parentRef:
+    name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+  hosts:
+    - pipelines.example.com
+  # optional basic auth (Envoy Gateway only)
+  basicAuth:
+    enabled: false
+    kind: envoy
+    authData: "" # base64-encoded htpasswd content
+```
+
+`rules` maps directly to the `HTTPRoute` `spec.rules` list, so any Gateway API rule
+field is supported (`matches`, `filters`, `backendRefs`, `timeouts`, ...). It defaults
+to a single `PathPrefix: /` rule routing to this chart's Service. String values are
+processed with Helm `tpl`, and a rule that omits `backendRefs` falls back to the chart's
+own Service on `service.port`. Override it to add multiple rules, custom matches or
+filters:
+
+```yaml
+gatewayApi:
+  enabled: true
+  hosts:
+    - pipelines.example.com
+  rules:
+    # route /badge to the chart Service (backendRefs defaulted)
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /badge
+    # everything else, with an explicit backend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: '{{ include "jxpipelines.fullname" . }}'
+          port: 80
+```
+
+Prerequisites and notes:
+- The Gateway API CRDs (`gateway.networking.k8s.io/v1`) must be installed in the cluster.
+- The `HTTPRoute` attaches to a **pre-existing** Gateway referenced by `parentRef`
+  (the chart does not create the Gateway). That Gateway owns TLS termination and must
+  allow routes from this namespace (`allowedRoutes`; a `ReferenceGrant` is needed if it
+  lives in another namespace, set via `parentRef.namespace`).
+- Basic auth is implemented with an [Envoy Gateway](https://gateway.envoyproxy.io/)
+  `SecurityPolicy` (`gateway.envoyproxy.io/v1alpha1`), so `basicAuth.kind: envoy`
+  requires Envoy Gateway as the controller.
+- `gatewayApi.enabled` and `ingress.enabled` can be set independently (e.g. during a
+  migration).
 
 ## Usage
 

--- a/charts/jx-pipelines-visualizer/templates/gatewayapi.yaml
+++ b/charts/jx-pipelines-visualizer/templates/gatewayapi.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.gatewayApi.enabled -}}
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "jxpipelines.fullname" . }}
+  labels:
+    {{- include "jxpipelines.labels" . | nindent 4 }}
+    {{- with .Values.gatewayApi.labels }}
+      {{- tpl (toYaml .) $ | trim | nindent 4 }}
+    {{- end }}
+  {{- with .Values.gatewayApi.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | trim | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ .Values.gatewayApi.parentRef.name }}
+    {{- with .Values.gatewayApi.parentRef.namespace }}
+    namespace: {{ . }}
+    {{- end }}
+    {{- with .Values.gatewayApi.parentRef.sectionName }}
+    sectionName: {{ . }}
+    {{- end }}
+  {{- if .Values.gatewayApi.hosts }}
+  hostnames:
+  {{- range .Values.gatewayApi.hosts }}
+  - {{ tpl . $ | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- range $rule := .Values.gatewayApi.rules }}
+  {{- if not $rule.backendRefs }}
+  {{- $_ := set $rule "backendRefs" (list (dict "group" "" "kind" "Service" "name" (include "jxpipelines.fullname" $) "port" (int $.Values.service.port))) }}
+  {{- end }}
+  {{- tpl (toYaml (list $rule)) $ | nindent 2 }}
+  {{- end }}
+
+{{- if and .Values.gatewayApi.basicAuth.enabled (eq (.Values.gatewayApi.basicAuth.kind | default "envoy") "envoy") }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ include "jxpipelines.fullname" . }}-basic-auth
+  labels:
+    {{- include "jxpipelines.labels" . | nindent 4 }}
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: {{ include "jxpipelines.fullname" . }}
+  basicAuth:
+    users:
+      name: {{ include "jxpipelines.fullname" . }}-basic-auth
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "jxpipelines.fullname" . }}-basic-auth
+  labels:
+    {{- include "jxpipelines.labels" . | nindent 4 }}
+type: Opaque
+data:
+  .htpasswd: {{ .Values.gatewayApi.basicAuth.authData | quote }}
+{{- end }}
+
+{{- end -}}

--- a/charts/jx-pipelines-visualizer/values.yaml
+++ b/charts/jx-pipelines-visualizer/values.yaml
@@ -100,10 +100,43 @@ istio:
   apiVersion: networking.istio.io/v1beta1
   gateway: jx-gateway
 
+gatewayApi:
+  # use Gateway API for networking
+  enabled: false
+
+  labels: {}
+  annotations: {}
+
+  # a (pre-existing) Gateway to attach to
+  parentRef:
+    name: envoy-gateway
+    namespace: envoy-gateway-system
+    sectionName: https
+
+  # hosts:
+  # - pipelines.example.com
+  hosts: []
+
+  # list of HTTPRoute spec.rules
+  # if a rule omits backendRefs, default to this Service on service.port
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+
+  # Basic auth for the route
+  basicAuth:
+    enabled: false
+    # Implementation backend
+    kind: envoy # supported values: "envoy"
+    # base64-encoded htpasswd file content (stored under the .htpasswd secret key)
+    authData: ""
+
 jx:
   # whether to create a Release CRD when installing charts with Release CRDs included
   releaseCRD: true
-  
+
 serviceAccount:
   # allow additional annotations to be added to the ServiceAccount
   # such as for workload identity on clouds


### PR DESCRIPTION
### Changes

* Create `gatewayapi.yaml` template
* Add `gatewayApi` block with defaults to values
* Update README

 ### Context

This PR adds Gateway API support via the `gatewayApi` block. This is an alternative to the existing Ingress resource for exposing the UI.

There is no one-to-one feature parity with Ingress, so the chart must make some further assumptions about the end-user's cluster setup:
* A pre-existing Gateway implementation must be installed in the cluster. The user's Gateway owns TLS termination, so is not included here
* JayeX versionStream natively supports Envoy Gateway, so the default are geared to use this:
  * `parentRef` points to `envoy-gateway` & `envoy-gateway-system`
  * Basic Auth implemented with an Envoy Gateway `SecurityPolicy` (`gatewayApi.basicAuth.kind: envoy`)
                                                                                                                                                                                                                                                                                                                                                           
`gatewayApi.enabled` and `ingress.enabled` are independent, so both can be set during a migration. Everything defaults to `enabled: false`, so this is a no-op for existing installs.

Part of https://github.com/jenkins-x/jx/issues/8962