### PR TITLE
chore: enable use of existingSecret for basic auth

### DIFF
--- a/charts/jx-pipelines-visualizer/templates/gatewayapi.yaml
+++ b/charts/jx-pipelines-visualizer/templates/gatewayapi.yaml
@@ -54,7 +54,8 @@ spec:
     name: {{ include "jxpipelines.fullname" . }}
   basicAuth:
     users:
-      name: {{ include "jxpipelines.fullname" . }}-basic-auth
+      name: {{ .Values.gatewayApi.basicAuth.existingSecret | default (printf "%s-basic-auth" (include "jxpipelines.fullname" .)) }}
+{{- if not .Values.gatewayApi.basicAuth.existingSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -65,6 +66,7 @@ metadata:
 type: Opaque
 data:
   .htpasswd: {{ .Values.gatewayApi.basicAuth.authData | quote }}
+{{- end }}
 {{- end }}
 
 {{- end -}}

--- a/charts/jx-pipelines-visualizer/values.yaml
+++ b/charts/jx-pipelines-visualizer/values.yaml
@@ -101,39 +101,28 @@ istio:
   gateway: jx-gateway
 
 gatewayApi:
-  # use Gateway API for networking
   enabled: false
-
   labels: {}
   annotations: {}
-
-  # a (pre-existing) Gateway to attach to
   parentRef:
     name: envoy-gateway
     namespace: envoy-gateway-system
     sectionName: https
-
   # hosts:
   # - pipelines.example.com
   hosts: []
-
-  # list of HTTPRoute spec.rules
-  # if a rule omits backendRefs, default to this Service on service.port
   rules:
   - matches:
     - path:
         type: PathPrefix
         value: /
-
   # Basic auth for the route
   basicAuth:
     enabled: false
-    # Implementation backend
     kind: envoy # supported values: "envoy"
     # base64-encoded htpasswd file content (stored under the .htpasswd secret key)
     authData: ""
-    # when set, reference this existing secret (must contain a ".htpasswd" key)
-    # instead of creating one from authData
+    # existing secret must contain a ".htpasswd" key
     existingSecret: ""
 
 jx:

--- a/charts/jx-pipelines-visualizer/values.yaml
+++ b/charts/jx-pipelines-visualizer/values.yaml
@@ -132,6 +132,9 @@ gatewayApi:
     kind: envoy # supported values: "envoy"
     # base64-encoded htpasswd file content (stored under the .htpasswd secret key)
     authData: ""
+    # when set, reference this existing secret (must contain a ".htpasswd" key)
+    # instead of creating one from authData
+    existingSecret: ""
 
 jx:
   # whether to create a Release CRD when installing charts with Release CRDs included


### PR DESCRIPTION
### Changes:

* Add `gatewayApi.basicAuth.existingSecret` for basic auth in chart

### Context

Allows use of `jx-basic-auth-htpasswd` from jxboot's secret-schema in https://github.com/jenkins-x/jx3-versions